### PR TITLE
heading navigation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Publican is a tiny, simple, and very fast HTML-first static site generator.
 
-*This is a beta product! Please use it at your own risk!*
+Full documentation is available at [Publican.dev](https://publican.dev/).
 
-Full documentation, examples, and starter templates coming soon!
+*This is a beta product! Please use it at your own risk!*
 
 Features:
 
@@ -15,6 +15,7 @@ Features:
 * automatic creation of page navigation, in-page heading contents, paginated posts, and paginated tag lists
 * renders HTML or any other text-based file types
 * pass-through file copying
+* add virtual content and templates
 * custom string replacement
 * automatic minification options
 * hooks for custom processing functions
@@ -104,216 +105,29 @@ node publican.config.js
 Publican ignores all content files with names starting with an underscore, e.g. `_draft.md`. This restriction does not apply to template files.
 
 
-## Front matter
+### Front matter
 
-You can add any front matter to content files but the following values control publication:
+You can add any front matter to any content file but the following values control publication:
 
 |name|description|
 |-|-|
 |`title`|page title (optional)|
 |`menu`|title used on menus or set `false` to omit (optional)|
 |`slug`|page slug (optional)|
-|`template`|HTML template filename (in template directory)|
-|`tags`|comma-delimited list of tags|
+|`priority`|post priority from 0 (least important) to 1 (most important)|
 |`date`|date of post|
 |`publish`|date of publication or `draft` determine whether post is published|
-|`priority`|post priority from 0 (least important) to 1 (most important)|
+|`tags`|comma-delimited list of tags|
+|`template`|HTML template filename (in template directory)|
 |`index`|indexing frequency (daily, weekly, monthly, yearly) or `false` to not index|
 |`debug`|set `true` to output content properties|
 
 Note that front matter can contain `${ expressions }`.
 
 
-## Content
+### In-page navigation
 
-Add a `<nav-heading></nav-heading>` element in any content or template to add a contents section with links to the main content headings (H2 to H6).
-
-
-## Post properties
-
-Post information can be analysed and used in templates with a `data` object that has the front matter properties above, any custom properties you set, and the following properties:
-
-|name|description|
-|-|-|
-|`filename`|original name of data file|
-|`slug`|rendered file name|
-|`link`|link to post|
-|`directory`|top-level directory name|
-|`date`|date of post|
-|`publish`|false if the post is not to published|
-|`priority`|post priority from 0 - 1|
-|`isMD`|content provided in markdown format|
-|`isHTML`|content is rendered to HTML|
-|`isXML`|content is rendered to XML|
-|`index`|indexing frequency (daily, weekly, monthly, yearly) or `false` if not indexed|
-|`tags`|array of tag objects: { tag, ref, link, slug }|
-|`content`|page content|
-|`contentRendered`|final rendered page content (post templating)|
-|`wordCount`|content word count|
-|`postnext`|`data` object of the next post in the directory|
-|`postback`|`data` object the previous post in the directory|
-|`pagination`|[pagination data](#pagination-properties)|
-
-
-### Pagination properties
-
-The `data.pagination` object contains the following properties when available:
-
-|name|description|
-|-|-|
-|`page`|array of pages|
-|`pageTotal`|total number of pages|
-|`pageCurrent`|current page number (zero based)|
-|`pageCurrent1`|current page number (one based)|
-|`subpageFrom1`|post number from|
-|`subpageTo1`|post number to|
-|`hrefBack`|link to previous paginated page|
-|`hrefNext`|link to next paginated page|
-|`href`|array of links to all paginated pages|
-
-
-## Global values
-
-The following values are available in all pages:
-
-|name|description|
-|-|-|
-|`tacs.root`|root build directory (defaults to `/`)|
-|`tacs.all`|Map object of all posts indexed by slug|
-|`tacs.dir`|Map object of all posts in a root directory. Returns an array of posts.|
-|`tacs.tag`|Map object of all tags. Returns an array of posts.|
-|`tacs.tagList`|array of tag objects: { tag, ref (normalized tag), link, slug, count }|
-|`tacs.nav`|nested array of navigation item objects: { data: {}, children \[ { data,children },... \] }|
-
-
-## Publican configuration
-
-Publican configuration is set in a `publican.config` object with the following properties (defaults shown in brackets):
-
-|property|description|
-|-|-|
-|`.dir.content`|content directory (`./src/content/`)|
-|`.dir.template`|template directory (`./src/template/`)|
-|`.dir.build`|build directory (`./build/`)|
-|`.defaultHTMLTemplate`|default template for HTML files (`default.html`)|
-|`.root`|root path (`/`)|
-|`.ignoreContentFile`|ignore file regex (anything starting `_`)|
-|`.slugReplace`|slug replacer Map|
-|`.frontmatterDelimit`|front matter delimiter (`---`)|
-|`.indexFrequency`|default indexing frequency (`monthly`). Set `false` to prevent sitemap indexing|
-|`.markdownOptions.core`|[markdown-it core options](https://github.com/markdown-it/markdown-it?tab=readme-ov-file#init-with-presets-and-options) object|
-|`.markdownOptions.prism`|[markdown-it-prism syntax highlighting options](https://github.com/jGleitz/markdown-it-prism?tab=readme-ov-file#options) object|
-|`.headingAnchor`|heading anchor and contents block options object|
-|`.dirPages`|directory pages options object {`size`, `sortBy`, `sortOrder`, `template`, `dir`}|
-|`.tagPages`|tag page index options object {`root`, `size`, `sortBy`, `sortOrder`, `template`, `menu`, `index`}|
-|`.minify`|[HTML minification options](https://github.com/kangax/html-minifier?tab=readme-ov-file#options-quick-reference) object|
-|`.passThrough`|file copy Set|
-|`.replace`|string replacer Map|
-|`.processContent`|function hook Set for content files (`filename`, `object`)|
-|`.processTemplate`|function hook Set for template files (`filename`, `string`) - returns string|
-|`.processRenderStart`|function hook Set called once prior to rendering ()|
-|`.processPreRender`|function hook Set prior to rendering post (`slug`, `object`)|
-|`.processPostRender`|function hook Set after rendering post (`slug`, `string`) - returns string|
-|`.processRenderComplete`|function hook Set called once after rendering (changed file list `[{slug,content},...]`)|
-|`.watch`|enable watch mode (`false`)|
-|`.watchDebounce`|watch debounce in milliseconds (`300`)|
-|`.logLevel`|log verbosity, `0` to `2` (`2`)|
-
-
-### Pass-through files
-
-Copy static files into the build directory using:
-
-```js
-publican.config.passThrough.add({ from: <src>, to: <dest> });
-```
-
-where:
-
-* `<src>` is a source directory relative to the project root, and
-* `<dest>` is a destination directory relative to the build directory
-
-Examples:
-
-```js
-// copy static files
-publican.config.passThrough.add({ from: './src/media/images/', to: 'images/' });
-publican.config.passThrough.add({ from: './src/css/', to: 'css/' });
-```
-
-
-### Custom string replacement
-
-Built files can have strings replaced:
-
-```js
-publican.config.replace.set(<search>, <replace>);
-```
-
-where:
-
-* `<search>` is a search string or regular expression
-* `<replace>` is the replacement string
-
-Examples:
-
-```js
-// replace __YEAR__ with the current year
-publican.config.replace.set( '__YEAR__', (new Date()).getUTCFullYear() );
-
-// replace text in <p class="bold"> with <p><strong>
-publican.config.replace.set( /<p class="bold">(.*?)<\/p>/ig, '<p><strong>$1</strong></p>);
-```
-
-
-### Custom jsTACS data and functions
-
-The `tacs` object can have any global data or functions appended although you should avoid changing the default [global values](#global-values). For example:
-
-```js
-tacs.generator = {
-  name: 'Publican',
-  url: 'https://www.npmjs.com/package/publican/'
-}
-```
-
-Any template can now use a render-time expression such as `${ tacs.generator.name }`.
-
-You can also create reusable functions to simplify rendering, e.g.
-
-```js
-tacs.exec = tacs.exec || {};
-
-// output links to most recent pages
-tacs.exec.listRecent = (list, maxSize = Infinity) => {
-
-  // copy list
-  list = [ ...list ];
-
-  // limit size
-  list.length = Math.min( list.length, maxSize );
-
-  // sort and generate list of links
-  let ret = list.
-    .sort((a, b) => b.date - a.date)
-    .map(i => `<li><a href="${ i.link }">${ i.title }</a></li>`)
-    .join('\n');
-
-  // make into list
-  if (ret) ret = `<ol>\n${ ret }</ol>\n`;
-
-  // return to template
-  return ret;
-
-};
-```
-
-Templates can now use this function, e.g. list the ten most recent posts in the `article` directory:
-
-```js
-<p>Ten most recent articles:</p>
-${ tacs.exec.listRecent( tacs.dir.get('article'), 10 ) }
-```
+Add a `<nav-heading></nav-heading>` element in any content or template to add a contents section with links to the main content headings (`h2` to `h6`).
 
 
 ### Virtual content and templates
@@ -357,6 +171,221 @@ publican.addTemplate(
 Content can refer to this template in front matter using `template: mytemplate.html`.
 
 Note the template string cannot be delimited with `` ` `` backticks if they contain `${ expressions }`.
+
+
+### Markdown notes
+
+You can use template literals in markdown content but some care may be necessary to avoid problems with the HTML conversion. Simple expressions such as `${ data.title }` will usually work as expected. However:
+
+* `${ expressions }` in code blocks will not execute
+* complex expressions such as `${ data.all.map(i => i.title) }` can break the markdown to HTML parser.
+
+
+To work around these restrictions, you can:
+
+1. Use a double-bracket `${{ expression }}`. This denotes a *real* expression irrespective of where it resides in the markdown.
+1. Use HTML snippets in your markdown file, such as `<p>${ expression }</p>`.
+1. Simplify expressions using [custom jsTACS functions](#custom-jstacs-data-and-functions).
+1. Only use complex expressions in HTML content or template files.
+
+You can used escape characters to avoid any template expression processing:
+
+* for `` ` `` backticks, use `&#96;`
+* for `${`, use `&#36;{`
+* for `!{`, use `&#33;{`
+
+
+## Post properties
+
+Post information can be analysed and used in content or templates using a `data` object that has the [front matter properties](#front-matter) above, any custom properties you add, and and other properties set by Publican.
+
+|name|description|
+|-|-|
+|`title`|page title|
+|`menu`|title used in menus|
+|`content`|main content|
+|`contentRendered`|final rendered main content|
+|`date`|date of post|
+|`publish`|false if the post is not to published|
+|`index`|indexing frequency (daily, weekly, monthly, yearly) or `false` if not indexed|
+|`priority`|post priority from 0 - 1|
+|`tags`|array of tag objects: { tag, ref, link, slug }|
+|`wordCount`|content word count|
+|`postnext`|`data` object of the next post in the directory|
+|`postback`|`data` object the previous post in the directory|
+|`pagination`|[pagination data](#pagination-properties)|
+|`filename`|original name of data file|
+|`template`|HTML template filename (in template directory)|
+|`slug`|the rendered filename relative to the build directory|
+|`link`|link to post|
+|`directory`|top-level directory name|
+|`isMD`|content provided in markdown format|
+|`isHTML`|content is rendered to HTML|
+|`isXML`|content is rendered to XML|
+|`debug`|whether debugging is enabled|
+
+
+### Pagination properties
+
+The `data.pagination` object contains the following properties when available:
+
+|name|description|
+|-|-|
+|`page`|array of pages|
+|`pageTotal`|total number of pages|
+|`pageCurrent`|current page number (zero based)|
+|`pageCurrent1`|current page number (one based)|
+|`subpageFrom1`|post number from|
+|`subpageTo1`|post number to|
+|`hrefBack`|link to previous paginated page|
+|`hrefNext`|link to next paginated page|
+|`href`|array of links to all paginated pages|
+
+
+## Global values
+
+The following values are available in all pages:
+
+|name|description|
+|-|-|
+|`tacs.root`|root build directory (defaults to `/`)|
+|`tacs.all`|Map object of all posts indexed by slug|
+|`tacs.dir`|Map object of all posts in a root directory. Returns an array of posts.|
+|`tacs.tag`|Map object of all tags. Returns an array of posts.|
+|`tacs.tagList`|array of tag objects: { tag, ref (normalized tag), link, slug, count }|
+|`tacs.nav`|nested array of navigation item objects: { data: {}, children \[ { data,children },... \] }|
+
+
+## Publican configuration
+
+Publican configuration is set in a `publican.config` object with the following properties (defaults shown in brackets):
+
+|property|description|
+|-|-|
+|`.dir.content`|content directory (`./src/content/`)|
+|`.dir.template`|template directory (`./src/template/`)|
+|`.dir.build`|build directory (`./build/`)|
+|`.ignoreContentFile`|ignore file regex (anything starting `_`)|
+|`.slugReplace`|slug replacer Map|
+|`.frontmatterDelimit`|front matter delimiter (`---`)|
+|`.root`|root path (`/`)|
+|`.indexFrequency`|default indexing frequency (`monthly`). Set `false` to prevent sitemap indexing|
+|`.defaultHTMLTemplate`|default template for HTML files (`default.html`)|
+|`.markdownOptions.core`|[markdown-it core options](https://github.com/markdown-it/markdown-it?tab=readme-ov-file#init-with-presets-and-options) object|
+|`.markdownOptions.prism`|[markdown-it-prism syntax highlighting options](https://github.com/jGleitz/markdown-it-prism?tab=readme-ov-file#options) object|
+|`.headingAnchor`|heading anchor and contents block options object {`nolink`, `linkContent`, `linkClass`, `nomenu`, `navClass`, `tag`}|
+|`.replace`|string replacer Map|
+|`.dirPages`|directory pages options object {`size`, `sortBy`, `sortOrder`, `template`, `dir`}|
+|`.tagPages`|tag page index options object {`root`, `size`, `sortBy`, `sortOrder`, `template`, `menu`, `index`}|
+|`.minify`|[HTML minification options](https://github.com/kangax/html-minifier?tab=readme-ov-file#options-quick-reference) object|
+|`.passThrough`|file copy Set|
+|`.processContent`|function hook Set for content files (`filename`, `object`)|
+|`.processTemplate`|function hook Set for template files (`filename`, `string`) - returns string|
+|`.processRenderStart`|function hook Set called once prior to rendering ()|
+|`.processPreRender`|function hook Set prior to rendering post (`slug`, `object`)|
+|`.processPostRender`|function hook Set after rendering post (`slug`, `string`) - returns string|
+|`.processRenderComplete`|function hook Set called once after rendering (changed file list `[{slug,content},...]`)|
+|`.watch`|enable watch mode (`false`)|
+|`.watchDebounce`|watch debounce in milliseconds (`300`)|
+|`.logLevel`|log verbosity, `0` to `2` (`2`)|
+
+
+### Custom string replacement
+
+Built files can have strings replaced:
+
+```js
+publican.config.replace.set(<search>, <replace>);
+```
+
+where:
+
+* `<search>` is a search string or regular expression
+* `<replace>` is the replacement string
+
+Examples:
+
+```js
+// replace __YEAR__ with the current year
+publican.config.replace.set( '__YEAR__', (new Date()).getUTCFullYear() );
+
+// replace text in <p class="bold"> with <p><strong>
+publican.config.replace.set( /<p class="bold">(.*?)<\/p>/ig, '<p><strong>$1</strong></p>);
+```
+
+
+### Pass-through files
+
+Copy static files into the build directory using:
+
+```js
+publican.config.passThrough.add({ from: <src>, to: <dest> });
+```
+
+where:
+
+* `<src>` is a source directory relative to the project root, and
+* `<dest>` is a destination directory relative to the build directory
+
+Examples:
+
+```js
+// copy ./src/media/favicons/**/* to ./build/
+publican.config.passThrough.add({ from: './src/media/favicons', to: './' });
+
+// copy ./src/media/images/**/* to ./build/images/
+publican.config.passThrough.add({ from: './src/media/images', to: './images/' });
+```
+
+
+### Custom jsTACS data and functions
+
+The `tacs` object can have any global data or functions appended although you should avoid changing the default [global values](#global-values). For example:
+
+```js
+tacs.generator = {
+  name: 'Publican',
+  url: 'https://www.npmjs.com/package/publican/'
+};
+```
+
+Any template can now use a render-time expression such as `${ tacs.generator.name }`.
+
+You can also create reusable functions to simplify rendering, e.g.
+
+```js
+tacs.exec = tacs.exec || {};
+
+// output links to most recent pages
+tacs.exec.listRecent = (list, maxSize = Infinity) => {
+
+  // copy list
+  list = [ ...list ];
+
+  // limit size
+  list.length = Math.min( list.length, maxSize );
+
+  // sort and generate list of links
+  let ret = list.
+    .sort((a, b) => b.date - a.date)
+    .map(i => `<li><a href="${ i.link }">${ i.title }</a></li>`)
+    .join('\n');
+
+  // make into list
+  if (ret) ret = `<ol>\n${ ret }</ol>\n`;
+
+  // return to template
+  return ret;
+
+};
+```
+
+Templates can now use this function, e.g. list the ten most recent posts in the `article` directory:
+
+```js
+<p>Ten most recent articles:</p>
+${ tacs.exec.listRecent( tacs.dir.get('article'), 10 ) }
+```
 
 
 ### Processing function hooks
@@ -412,24 +441,3 @@ publican.config.processPostRender.add(
   }
 );
 ```
-
-
-## Notes
-
-Avoid JavaScript expressions in markdown content. Simple expressions are generally fine, e.g. `${ data.title }`, but the markdown process will:
-
-* alter complex expressions such as `${ data.all.map(i => i.title) }`, and
-* escape expressions in code blocks so no code will run.
-
-To work around these restrictions, you can:
-
-1. Use the `${{ expression }}` notation. This denotes a *real* expression irrespective of where it resides in the markdown.
-1. Move expressions into the HTML template file.
-1. [Create jsTACS functions](#custom-jstacs-data-and-functions) to simplify the expression.
-1. Change the `.md` file to `.html` and author HTML instead.
-
-You can used escape characters to avoid any template expression processing:
-
-* for `` ` `` backticks, use `&#96;`
-* for `${`, use `&#36;{`
-* for `!{`, use `&#33;{`

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -132,7 +132,7 @@ export function mdHTML(str, mdOpts = mdConfig) {
     str = str
       .replace(/(<code class="language-.+?)\$\{(.+?<\/code>)/gis, '$1&#36;{$2') // escape ${
       .replace(/(<code class="language-.+?)!\{(.+?<\/code>)/gis, '$1&#33;{$2')  // escape !{
-      .replace(/(<code class="language-.+?)`(.+?<\/code>)/gis, '$1&#96;$2')  // escape `
+      .replace(/(<code class="language-.+?)`(.+?<\/code>)/gis, '$1&#96;$2')     // escape `
       .replace(/(<code class="language-.+?)\\(.+?<\/code>)/gis, '$1&#92;$2');   // escape \
   } while (str !== oc);
 
@@ -158,23 +158,42 @@ export function navHeading(str, haOpt) {
   const idCount = {};
   let navHeading = '', clevel = 1;
 
-  str = str.replace(/<(h[2-6])(.?)>(.+?)<\/h[2-6]>/gi,
+  str = str.replace(/<(h[2-6])(.*?)>(.*?)<\/h[2-6]>/gis,
     (m, p1, p2, p3) => {
 
-      // generate ID
-      let id = p3
-        .replace(/<.*?>/g, '')
-        .replace(/[^\w\s]/g, '')
-        .replace(/\s+/g, '-')
-        .toLowerCase();
+      // add heading link?
+      const addLink = !haOpt.nolink || !p2.includes(haOpt.nolink);
 
-      // ensure ID starts with a letter
-      const fc = id.slice(0, 1);
-      if (fc < 'a' || fc > 'z') id = 'a-' + id;
+      // add menu link?
+      const addMenu = !haOpt.nomenu || !p2.includes(haOpt.nomenu);
 
-      // handle duplicate IDs
-      idCount[id] = (idCount[id] || 0) + 1;
-      if (idCount[id] > 1) id += `-${ idCount[id ]}`;
+      // add tabindex?
+      const addTabindex = (addLink || addMenu) && !p2.includes('tabindex=');
+
+      // ID set?
+      let idUsed = p2.match(/id=(?:"|'){0,1}([^"|'|\s]+)(?:"|'|\s)/i);
+      idUsed = idUsed && idUsed[1];
+      let id = idUsed;
+
+      if (!id && (addLink || addMenu)) {
+
+        // generate ID
+        id = p3
+          .replace(/<.*?>/g, '')
+          .replace(/[^\w\s]/g, '')
+          .replace(/\s+/g, '-')
+          .toLowerCase();
+
+        // ensure ID starts with a letter
+        const fc = id.slice(0, 1);
+        if (fc < 'a' || fc > 'z') id = 'a-' + id;
+
+        // handle duplicate IDs
+        idCount[id] = (idCount[id] || 0) + 1;
+        if (idCount[id] > 1) id += `-${ idCount[id ]}`;
+
+      }
+      else idUsed = true;
 
       // update contents navigation
       const pl = parseFloat(p1.slice(-1));
@@ -183,16 +202,19 @@ export function navHeading(str, haOpt) {
       for (let p = pl; p < clevel; p++) navHeading += '\n</li></ol>\n';
       if (pl <= clevel) navHeading += '</li>\n<li>';
 
-      navHeading += `<a href="#${ id }" class="head-${ p1 }">${ p3 }</a>`;
+      if (addMenu) navHeading += `<a href="#${ id }" class="head-${ p1 }">${ p3 }</a>`;
       clevel = pl;
 
       // update heading
-      return `<${ p1 }${ p2 } id="${ id }" tabindex="-1">${ p3 } <a href="#${ id }" class="${ haOpt.linkClass }">${ haOpt.linkContent }</a></${ p1 }>`;
+      return `<${ p1 }${ p2 }${ idUsed ? '' : ` id="${ id }"` }${ addTabindex ? ' tabindex="-1"' : '' }>${ p3 }${ addLink ? ` <a href="#${ id }" class="${ haOpt.linkClass }">${ haOpt.linkContent }</a>` : ''}</${ p1 }>`;
     }
   );
 
   if (navHeading) {
-    navHeading = `<nav class="${ haOpt.navClass }">${ navHeading }\n${ '</li></ol>'.repeat(clevel - 1) }\n</nav>`;
+    navHeading = `<nav class="${ haOpt.navClass }">${ navHeading }\n${ '</li></ol>'
+      .repeat(clevel - 1) }\n</nav>`
+      .replace(/<li>\s*<\/li>/ig, '')
+      .replace(/<ol>\s*<\/ol>/ig, '');
   }
 
   return { content: str, navHeading };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "publican",
-  "version": "0.4.0",
-  "description": "Simple and fast HTML-first static site generator",
+  "version": "0.5.0",
+  "description": "Publican is a simple and fast HTML-first static site generator for Node.js",
   "type": "module",
   "main": "publican.js",
   "exports": "./publican.js",

--- a/publican.js
+++ b/publican.js
@@ -73,8 +73,10 @@ export class Publican {
 
       // heading anchors
       headingAnchor: {
+        nolink: 'nolink',
         linkContent: '#',
         linkClass: 'headlink',
+        nomenu: 'nomenu',
         navClass: 'contents',
         tag: 'nav-heading'
       },

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -3,6 +3,7 @@ import { slugify, properCase, normalize, extractFmContent, parseFrontMatter, mdH
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
+
 describe('lib.js/slugify function', () => {
 
   const pad = 20;
@@ -118,7 +119,6 @@ describe('lib.js/extractFmContent function', () => {
 });
 
 
-
 describe('lib.js/parseFrontMatter function', () => {
 
   [
@@ -159,8 +159,10 @@ describe('lib.js/mdHTML and navHeading functions', () => {
       }
     },
     headingAnchorOptions = {
+      nolink: 'nolink',
       linkContent: '#',
       linkClass: 'headlink',
+      nomenu: 'nomenu',
       navClass: 'contents'
     };
 
@@ -198,6 +200,29 @@ describe('lib.js/mdHTML and navHeading functions', () => {
       }
     },
 
+    {
+      md: '<h1>Main title</h1>\n<h2 id="h2a">Heading 2a</h2>\n<h3 class="nolink">Heading 3a</h3>\n<h3 class="nolink nomenu">Heading 3b</h3>\n<h2>Heading 2b</h2>\n<h3 id="h3b" tabindex="10" class="link">Heading 3b</h3>',
+      out: {
+        content: '<h1>Main title</h1>\n<h2 id="h2a" tabindex="-1">Heading 2a <a href="#h2a" class="headlink">#</a></h2>\n<h3 class="nolink" id="heading-3a" tabindex="-1">Heading 3a</h3>\n<h3 class="nolink nomenu">Heading 3b</h3>\n<h2 id="heading-2b" tabindex="-1">Heading 2b <a href="#heading-2b" class="headlink">#</a></h2>\n<h3 id="h3b" tabindex="10" class="link">Heading 3b <a href="#h3b" class="headlink">#</a></h3>',
+        navHeading: '<nav class="contents">\n<ol><li>\n<a href="#h2a" class="head-h2">Heading 2a</a>\n<ol><li>\n<a href="#heading-3a" class="head-h3">Heading 3a</a></li>\n</ol>\n</li>\n<li><a href="#heading-2b" class="head-h2">Heading 2b</a>\n<ol><li>\n<a href="#h3b" class="head-h3">Heading 3b</a>\n</li></ol></li></ol>\n</nav>'
+      }
+    },
+
+    {
+      md: '<h2>Heading 2a</h2>\n<h3 class="nolink nomenu">Heading 3a</h3>\n<h3 class="nomenu">Heading 3b</h3>\n<h3 class="nolink">Heading 3c</h3>\n<h2 class="nomenu">Heading 2b</h2>\n<h3>Heading 3d</h3>\n<h3>Heading 3e</h3>\n<h3 class="nomenu">Heading 3f</h3>',
+      out: {
+        content: '<h2 id="heading-2a" tabindex="-1">Heading 2a <a href="#heading-2a" class="headlink">#</a></h2>\n<h3 class="nolink nomenu">Heading 3a</h3>\n<h3 class="nomenu" id="heading-3b" tabindex="-1">Heading 3b <a href="#heading-3b" class="headlink">#</a></h3>\n<h3 class="nolink" id="heading-3c" tabindex="-1">Heading 3c</h3>\n<h2 class="nomenu" id="heading-2b" tabindex="-1">Heading 2b <a href="#heading-2b" class="headlink">#</a></h2>\n<h3 id="heading-3d" tabindex="-1">Heading 3d <a href="#heading-3d" class="headlink">#</a></h3>\n<h3 id="heading-3e" tabindex="-1">Heading 3e <a href="#heading-3e" class="headlink">#</a></h3>\n<h3 class="nomenu" id="heading-3f" tabindex="-1">Heading 3f <a href="#heading-3f" class="headlink">#</a></h3>',
+        navHeading: '<nav class="contents">\n<ol><li>\n<a href="#heading-2a" class="head-h2">Heading 2a</a>\n<ol>\n<li><a href="#heading-3c" class="head-h3">Heading 3c</a>\n</li></ol>\n</li>\n<li>\n<ol><li>\n<a href="#heading-3d" class="head-h3">Heading 3d</a></li>\n<li><a href="#heading-3e" class="head-h3">Heading 3e</a></li>\n</ol></li></ol>\n</nav>'
+      }
+    },
+
+    {
+      md: '<h4>Heading 0-h4</h4>\n<h2 class="nomenu">Heading 1-h2</h2>\n<h4>Heading 2-h4</h4>\n<h3>Heading 3-h3</h3>\n<h3>Heading 4-h3</h3>\n<h2>Heading 5-h2</h2>\n<h4>Heading 6-h4</h3>\n<h3>Heading 7-h3</h3>',
+      out: {
+        content: '<h4 id="heading-0h4" tabindex="-1">Heading 0-h4 <a href="#heading-0h4" class="headlink">#</a></h4>\n<h2 class="nomenu" id="heading-1h2" tabindex="-1">Heading 1-h2 <a href="#heading-1h2" class="headlink">#</a></h2>\n<h4 id="heading-2h4" tabindex="-1">Heading 2-h4 <a href="#heading-2h4" class="headlink">#</a></h4>\n<h3 id="heading-3h3" tabindex="-1">Heading 3-h3 <a href="#heading-3h3" class="headlink">#</a></h3>\n<h3 id="heading-4h3" tabindex="-1">Heading 4-h3 <a href="#heading-4h3" class="headlink">#</a></h3>\n<h2 id="heading-5h2" tabindex="-1">Heading 5-h2 <a href="#heading-5h2" class="headlink">#</a></h2>\n<h4 id="heading-6h4" tabindex="-1">Heading 6-h4 <a href="#heading-6h4" class="headlink">#</a></h4>\n<h3 id="heading-7h3" tabindex="-1">Heading 7-h3 <a href="#heading-7h3" class="headlink">#</a></h3>',
+        navHeading: '<nav class="contents">\n<ol><li>\n<ol><li>\n<ol><li>\n<a href="#heading-0h4" class="head-h4">Heading 0-h4</a>\n</li></ol>\n</li></ol>\n</li>\n<li>\n<ol><li>\n<ol><li>\n<a href="#heading-2h4" class="head-h4">Heading 2-h4</a>\n</li></ol>\n</li>\n<li><a href="#heading-3h3" class="head-h3">Heading 3-h3</a></li>\n<li><a href="#heading-4h3" class="head-h3">Heading 4-h3</a>\n</li></ol>\n</li>\n<li><a href="#heading-5h2" class="head-h2">Heading 5-h2</a>\n<ol><li>\n<ol><li>\n<a href="#heading-6h4" class="head-h4">Heading 6-h4</a>\n</li></ol>\n</li>\n<li><a href="#heading-7h3" class="head-h3">Heading 7-h3</a>\n</li></ol></li></ol>\n</nav>'
+      }
+    },
 
   ].forEach((set, idx) => {
 
@@ -213,7 +238,6 @@ describe('lib.js/mdHTML and navHeading functions', () => {
   });
 
 });
-
 
 
 describe('lib.js/chunk function', () => {


### PR DESCRIPTION
New options for in-page navigation. Set:

* `publican.headingAnchor.nolink` (default is `nolink`) to not add a heading # link when found in tag.
* `publican.headingAnchor.nomenu` (default is `nomenu`) to not add the heading to the `<nav-heading>` menu when found in the tag

Examples:
```
<h2 class="nolink nomenu">Unchanged</h2>
<!-- unchanged -->

<h2 data-nolink>heading</h2>
<!-- becomes <h2 id="heading" tabindex="-1" data-nolink>Heading</h2> but appears in menu -->
```