### PR TITLE
virtual posts as data objects, templates in markdown format

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -78,7 +78,7 @@ export function normalize(str) {
 // split a string into front matter and content
 export function extractFmContent(str, fmDelimit = '---') {
 
-  str = str.trim();
+  str = String(str || '').trim();
 
   const
     fmdLen = fmDelimit.length,
@@ -425,7 +425,7 @@ export async function fileInfo(path) {
     info.modified = i.mtimeMs;
 
   }
-  catch (e) {}
+  catch {}
 
   return info;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publican",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Publican is a simple and fast HTML-first static site generator for Node.js",
   "type": "module",
   "main": "publican.js",
@@ -41,7 +41,7 @@
     "html-minifier-security-fix": "4.0.0",
     "jstacs": "0.3.0",
     "markdown-it": "14.1.0",
-    "markdown-it-prism": "3.0.0",
+    "markdown-it-prism": "3.0.1",
     "perfpro": "0.2.0"
   }
 }


### PR DESCRIPTION
1. `addContent` supports data objects

   Can pass an optional `dataObject` with name/value pairs instead of using front matter:

   ```publican.addContent( <filename>, <content> [, <dataObject> ] );```

1. Markdown templates

   Templates can now be markdown files which are converted to HTML.